### PR TITLE
Use `//` instead of `/` for integer division (Bazel incompatible change)

### DIFF
--- a/lib/json_parser.bzl
+++ b/lib/json_parser.bzl
@@ -555,7 +555,7 @@ def _reduce_array(reductions):
 
 def _reduce_object(reductions):
     obj = dict()
-    for i in range(0, len(reductions) / 2):
+    for i in range(0, len(reductions) // 2):
         idx = i * 2
         key = reductions[idx]["reduction"]
         val = reductions[idx + 1]["reduction"]


### PR DESCRIPTION
```
	File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/526e975d8598b00abba8a162c79fef75/external/bazel_json/lib/json_parser.bzl", line 661, in json_parse
		_handle_next_char(parser, json_string = json_string, c...)
	File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/526e975d8598b00abba8a162c79fef75/external/bazel_json/lib/json_parser.bzl", line 436, in _handle_next_char
		_pop(checker, _MODES["OBJECT"])
	File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/526e975d8598b00abba8a162c79fef75/external/bazel_json/lib/json_parser.bzl", line 278, in _pop
		_reduce(checker)
	File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/526e975d8598b00abba8a162c79fef75/external/bazel_json/lib/json_parser.bzl", line 368, in _reduce
		checker["reduction_hooks"][reducer_name](upstream_reductions)
	File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/526e975d8598b00abba8a162c79fef75/external/bazel_json/lib/json_parser.bzl", line 558, in checker["reduction_hooks"][reducer_name]
		range(0, (len(reductions) / 2))
	File "/usr/local/google/home/jingwen/.cache/bazel/_bazel_jingwen/526e975d8598b00abba8a162c79fef75/external/bazel_json/lib/json_parser.bzl", line 558, in range
		len(reductions) / 2
The `/` operator has been removed. Please use the `//` operator for integer division. You can temporarily enable the `/` operator by passing the flag --incompatible_disallow_slash_operator=false
```