### PR TITLE
Updated to work with Bazel 4.1 and bazel-sylib 1.0.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,12 +1,16 @@
 workspace(name = "bazel_json")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-# https://github.com/bazelbuild/bazel-skylib
+
 http_archive(
     name = "bazel_skylib",
-    sha256 = "d7cffbed034d1203858ca19ff2e88d241781f45652a4c719ed48eedc74bc82a9",
-    strip_prefix = "bazel-skylib-0.3.1",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
     urls = [
-        "https://github.com/bazelbuild/bazel-skylib/archive/0.3.1.tar.gz",
-    ]
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.3/bazel-skylib-1.0.3.tar.gz",
+    ],
 )
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,3 +1,8 @@
-# package(default_visibility = ["//:__pkg__"])
-# package(default_visibility = ["//visibility:public"])
-exports_files(["json_parser.bzl"])
+package(default_visibility = ["//visibility:public"])
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "json_parser",
+    srcs = ["json_parser.bzl"],
+)

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,1 +1,3 @@
-package(default_visibility = ["//:__pkg__"])
+# package(default_visibility = ["//:__pkg__"])
+# package(default_visibility = ["//visibility:public"])
+exports_files(["json_parser.bzl"])

--- a/test/json_parse_tests.bzl
+++ b/test/json_parse_tests.bzl
@@ -1,16 +1,16 @@
-load("@bazel_skylib//:lib.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//lib:json_parser.bzl", "json_parse")
 load(":json_parse_test_data.bzl", "get_pkg_jsons")
-
 
 def _valid_json_parse_test(ctx):
     env = unittest.begin(ctx)
 
-    asserts.equals(env, json_parse('[]'), [])
+    asserts.equals(env, json_parse("[]"), [])
     asserts.equals(
         env,
         json_parse('["x", "y", 22, [7], {"z": 1, "y": null}]'),
-        ["x", "y", 22, [7], {"z" : 1, "y" : None}])
+        ["x", "y", 22, [7], {"z": 1, "y": None}],
+    )
     asserts.equals(
         env,
         " ".join(reversed(json_parse('["plain", "the", "on", "mainly", "falls", "spain", "in", "rain", "the"]'))),
@@ -19,29 +19,33 @@ def _valid_json_parse_test(ctx):
     asserts.equals(
         env,
         json_parse('["a", "b", "c", [1, 2, 3, [4], [5], [6]]]'),
-        ["a", "b", "c", [1, 2, 3, [4], [5], [6]]])
-    asserts.equals(env, json_parse('{}'), {})
-    asserts.equals(env, json_parse('{"a" : "b"}'), { "a" : "b" })
+        ["a", "b", "c", [1, 2, 3, [4], [5], [6]]],
+    )
+    asserts.equals(env, json_parse("{}"), {})
+    asserts.equals(env, json_parse('{"a" : "b"}'), {"a": "b"})
     asserts.equals(
         env,
         json_parse('{"key1": [1, 2, ["nested"]], "key2": "val2", "key3": {"nested_key1" : [null, true, false]}}'),
         {
-            "key1" : [1, 2, ["nested"]],
-            "key2" : "val2",
-            "key3" : {
-                "nested_key1" : [None, True, False]
-            }
-        })
+            "key1": [1, 2, ["nested"]],
+            "key2": "val2",
+            "key3": {
+                "nested_key1": [None, True, False],
+            },
+        },
+    )
 
     asserts.equals(
         env,
         json_parse('{"key:with:colon" : [{ "nested:with:colon" : true }]}'),
-        { "key:with:colon" : [{ "nested:with:colon" : True }] },
+        {"key:with:colon": [{"nested:with:colon": True}]},
     )
 
-    expected_escapes = { "escaped" : r'\"quotes\"'}
+    expected_escapes = {"escaped": r'\"quotes\"'}
+
     # Ughh... need to double escape the escape.
     asserts.equals(env, expected_escapes, json_parse('{"escaped" : "\\"quotes\\""}'))
+
     # Unless it's a raw literal
     asserts.equals(env, expected_escapes, json_parse(r'{"escaped" : "\"quotes\""}'))
     asserts.equals(
@@ -49,24 +53,23 @@ def _valid_json_parse_test(ctx):
         expected_escapes,
         json_parse(r'''
 {"escaped" : "\"quotes\""}
-'''))
+'''),
+    )
 
-    unittest.end(env)
-
+    return unittest.end(env)
 
 def _scalar_types_test(ctx):
     env = unittest.begin(ctx)
 
     asserts.equals(env, json_parse('[""]')[0], "")
     asserts.equals(env, json_parse('["a string"]')[0], "a string")
-    asserts.equals(env, json_parse('[true]')[0], True)
-    asserts.equals(env, json_parse('[false]')[0], False)
-    asserts.equals(env, json_parse('[null]')[0], None)
-    asserts.equals(env, json_parse('[100]')[0], 100)
-    asserts.equals(env, json_parse('[-100]')[0], -100)
+    asserts.equals(env, json_parse("[true]")[0], True)
+    asserts.equals(env, json_parse("[false]")[0], False)
+    asserts.equals(env, json_parse("[null]")[0], None)
+    asserts.equals(env, json_parse("[100]")[0], 100)
+    asserts.equals(env, json_parse("[-100]")[0], -100)
 
-    unittest.end(env)
-
+    return unittest.end(env)
 
 def _number_parse_test(ctx):
     env = unittest.begin(ctx)
@@ -75,35 +78,33 @@ def _number_parse_test(ctx):
     # https://tools.ietf.org/html/rfc8259#section-6
     # "This specification allows implementations to set limits on the range
     # and precision of numbers accepted."
-    asserts.equals(env, 2147483647, json_parse('[99e100]')[0]) # MAX int
-    asserts.equals(env, -2147483647, json_parse('[-99e100]')[0]) # MIN int
-    asserts.equals(env, 0, json_parse('[99e-10]')[0])
-    asserts.equals(env, 9, json_parse('[999e-2]')[0])
+    asserts.equals(env, 2147483647, json_parse("[99e100]")[0])  # MAX int
+    asserts.equals(env, -2147483647, json_parse("[-99e100]")[0])  # MIN int
+    asserts.equals(env, 0, json_parse("[99e-10]")[0])
+    asserts.equals(env, 9, json_parse("[999e-2]")[0])
 
-    asserts.equals(env, 43, json_parse('[43.11]')[0])
-    asserts.equals(env, 0, json_parse('[0.12345]')[0])
-    asserts.equals(env, -120, json_parse('[-120.12345]')[0])
+    asserts.equals(env, 43, json_parse("[43.11]")[0])
+    asserts.equals(env, 0, json_parse("[0.12345]")[0])
+    asserts.equals(env, -120, json_parse("[-120.12345]")[0])
 
-    unittest.end(env)
-
+    return unittest.end(env)
 
 def _max_depth_json_parse_test(ctx):
     env = unittest.begin(ctx)
 
     asserts.equals(
         env,
-        json_parse('[[[[[[[[[[[[[[[[[[[[20]]]]]]]]]]]]]]]]]]]]'),
-        [[[[[[[[[[[[[[[[[[[[20]]]]]]]]]]]]]]]]]]]]
+        json_parse("[[[[[[[[[[[[[[[[[[[[20]]]]]]]]]]]]]]]]]]]]"),
+        [[[[[[[[[[[[[[[[[[[[20]]]]]]]]]]]]]]]]]]]],
     )
 
     asserts.equals(
         env,
         json_parse('[[["too_deep"]]]', fail_on_invalid = False, max_depth = 2),
-        None
+        None,
     )
 
-    unittest.end(env)
-
+    return unittest.end(env)
 
 def _package_json_parse_test(ctx):
     env = unittest.begin(ctx)
@@ -121,8 +122,7 @@ def _package_json_parse_test(ctx):
         parsed_pkg_json = json_parse(pkg_jsons_for_testing[project])
         asserts.equals(env, "dict", type(parsed_pkg_json))
 
-    unittest.end(env)
-
+    return unittest.end(env)
 
 valid_json_parse_test = unittest.make(_valid_json_parse_test)
 scalar_types_test = unittest.make(_scalar_types_test)


### PR DESCRIPTION
- Upgraded to bazel-skylib 1.0.3
- Exposed `json_parser.bzl` using `bzl_library`.
- Updated tests to explicitly `return unittest.end(env)`.
- Some automatic format updates to the test file.